### PR TITLE
docs: actualizar documentacion - separar legacy vs reglas nuevas, corregir versiones

### DIFF
--- a/.agents/best-practices.md
+++ b/.agents/best-practices.md
@@ -1,5 +1,10 @@
 You are an expert in TypeScript, Angular, and scalable web application development. You write functional, maintainable, performant, and accessible code following Angular and TypeScript best practices.
 
+> **NOTA IMPORTANTE**: Estas reglas son para código **NUEVO**. El código existente
+> puede no seguir todas estas prácticas aún (legacy: constructor injection,
+> `*ngIf`/`*ngFor`, `standalone: true` explícito, sin signals).
+> Todo código nuevo DEBE seguir estas reglas.
+
 ## TypeScript Best Practices
 
 - Use strict type checking

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
 # AGENTS.md - Project Context for AI Agents
 
 ## Project Overview
-- **Framework**: Angular 21.2.7
+- **Framework**: Angular ^21.2.18
 - **Language**: TypeScript 5.9.3
 - **Package Manager**: pnpm (NOT npm)
 - **Testing**: Karma/Jasmine (unit) + Cypress E2E
+- **Linting**: ESLint 9.x + angular-eslint 21.x (flat config: `eslint.config.js`)
 
 ## Agent Skills
 
@@ -63,6 +64,7 @@ pnpm run lint:fix       # Auto-fix fixable issues
 - [ ] Build succeeds: `pnpm run build`
 - [ ] ESLint passes: `pnpm run lint` (warnings allowed)
 - [ ] No vulnerabilities: `pnpm audit` (ignores ajv tool vulnerability in devDeps)
+- [ ] Docs actualizados si cambiaron versiones/scripts/reglas
 
 ---
 
@@ -88,21 +90,37 @@ pnpm run lint:fix       # Auto-fix fixable issues
 - Trailing commas in multiline arrays/objects
 - Use semicolons at statement end
 
-## Angular Components
-- **DO NOT** set `standalone: true` (default in Angular 20+)
+## Current Code State (Legacy)
+
+> **El código existente NO sigue las reglas modernas de Angular 20+.**
+> Esta sección describe cómo ES el código actual, no cómo DEBE ser.
+
+- **Standalone**: Todos los componentes usan `standalone: true` explícito (aunque es default en Angular 20+)
+- **Inyección**: Constructor injection en todos los servicios y componentes (no usan `inject()`)
+- **Templates**: Usan `*ngIf`/`*ngFor` (structural directives legacy)
+- **Signals**: No se usan aún en el código fuente
+- **Inputs/Outputs**: Decoradores clásicos `@Input()`/`@Output()` (no `input()`/`output()` functions)
+- **Change Detection**: No todos usan `OnPush`
+
+## Rules for NEW Code (mandatory)
+
+> **Todo código nuevo DEBE seguir estas reglas.** El código legacy se migrará gradualmente.
+
+### Angular Components
+- **DO NOT** set `standalone: true` (default en Angular 20+)
 - Use `input()` and `output()` functions instead of decorators
 - Use `computed()` for derived state
 - Set `changeDetection: ChangeDetectionStrategy.OnPush`
 - Keep components small and focused (single responsibility)
 - Prefer inline templates for small components (< 50 lines)
 
-## State Management (Signals)
+### State Management (Signals)
 - Use signals for local component state
 - Use `computed()` for derived values
 - **NEVER** use `mutate()` - use `update()` or `set()`
 - Keep state transformations pure and predictable
 
-## Templates
+### Templates
 - Use native control flow: `@if`, `@for`, `@switch`
 - **NEVER** use `*ngIf`, `*ngFor`, `*ngSwitch`
 - **NEVER** use `ngClass` (use class bindings instead)
@@ -111,7 +129,7 @@ pnpm run lint:fix       # Auto-fix fixable issues
 - Use async pipe for observables
 - Keep templates simple; avoid complex logic
 
-## Services
+### Services
 - Use `inject()` instead of constructor injection
 - Use `providedIn: 'root'` for singleton services
 - Keep services focused on single responsibility
@@ -159,6 +177,8 @@ src/app/
 - Run tests with coverage before any commit
 - Branches coverage must be ≥ 80% (SonarQube requirement)
 - Cypress component testing has limitations with Angular 21; use E2E tests
-- ESLint configured with angular-eslint v18 + ESLint v8
+- ESLint configured with angular-eslint v21 + ESLint v9 (flat config: `eslint.config.js`)
 - Run `pnpm run lint` to check code style (warnings allowed)
 - Run `pnpm run lint:fix` to auto-fix some issues
+- Skills provide specialized instructions and workflows for specific tasks.
+Use the skill tool to load a skill when a task matches its description.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,24 @@ Si tu cambio afecta:
 - Arquitectura: Actualizar `AGENTS.md`
 - Tests: Actualizar sección de testing
 
+### Reglas de Actualización de AGENTS.md
+**Cuándo actualizar:**
+- Versiones de dependencias principales cambiadas (Angular, TypeScript, ESLint, etc.)
+- Nuevos patrones de código adoptados (signals, standalone real, etc.)
+- Scripts de build/test añadidos o modificados en `package.json`
+- Reglas de código cambiadas
+- Archivos importantes movidos o renombrados
+
+**Quién actualiza:**
+- El desarrollador que hace el cambio DEBE actualizar la documentación
+- Revisión en PR: verificar que la documentación esté actualizada
+
+**Checklist para cambios que requieren update de docs:**
+- [ ] ¿Cambió la versión de Angular/TypeScript/otros?
+- [ ] ¿Se añadieron/quitaron scripts en package.json?
+- [ ] ¿Cambiaron las reglas de código?
+- [ ] ¿Se movieron/renombraron archivos importantes?
+
 ### Comentarios en Código
 - Comentar código complejo
 - Usar JSDoc para funciones públicas

--- a/DOCS_INDEX.md
+++ b/DOCS_INDEX.md
@@ -17,6 +17,7 @@
 ### ⚙️ [.agents/best-practices.md](.agents/best-practices.md) (2.3KB)
 **Para**: Agentes IA y desarrolladores  
 **Contenido**: Mejores prácticas de TypeScript, Angular 20+, accesibilidad, patrones de código
+> **Nota**: Reglas para código nuevo. El código existente puede no seguirlas.
 
 ## 📦 Documentación de Migración a pnpm
 
@@ -157,10 +158,14 @@ pnpm audit              # Verificar seguridad
 ## 📝 Notas Importantes
 
 ### ⚠️ Deprecaciones
+> **Nota**: El código existente aún usa estas formas legacy. Las nuevas features
+> DEBEN usar la forma moderna. Ver `AGENTS.md` → "Current Code State (Legacy)".
+
 - **NO usar** `*ngIf`, `*ngFor`, `*ngSwitch` → Usar `@if`, `@for`, `@switch`
 - **NO usar** `ngClass`, `ngStyle` → Usar class/style bindings
 - **NO usar** decoradores `@Input()`, `@Output()` → Usar `input()`, `output()`
 - **NO usar** `standalone: true` en decoradores → Es el default en Angular 20+
+- **NO usar** constructor injection → Usar `inject()`
 
 ### ✅ Mejores Prácticas
 - Usar signals para estado
@@ -171,7 +176,7 @@ pnpm audit              # Verificar seguridad
 
 ### 🔒 Seguridad
 - Proyecto sin vulnerabilidades conocidas
-- Dependencias actualizadas a Angular 21.2.7
+- Dependencias actualizadas a Angular ^21.2.18
 - Usar `pnpm audit` regularmente
 - Skills de proyecto disponibles en `.agents/skills/`
 
@@ -195,6 +200,6 @@ pnpm audit              # Verificar seguridad
 
 ---
 
-**Última actualización**: 2 de abril de 2026  
+**Última actualización**: 26 de julio de 2026  
 **Mantenido por**: Equipo de desarrollo  
 **Versión del proyecto**: 0.2.0


### PR DESCRIPTION
Resumen: Actualiza la documentacion del proyecto para resolver el conflicto entre codigo actual y reglas aspiracionales.

Cambios realizados:
- AGENTS.md: Corregir version Angular, anadir ESLint v9 flat config, nueva seccion Current Code State (Legacy), seccion Rules for NEW Code (mandatory) separada, anadir item de docs al Pre-Commit Checklist
- .agents/best-practices.md: Nota aspiracional al inicio
- CONTRIBUTING.md: Reglas de actualizacion de documentacion
- DOCS_INDEX.md: Version corregida, nota legacy, fecha actualizada

Los agentes ahora tienen claro: como es el codigo actual, como debe ser el codigo nuevo, y cuando actualizar la documentacion.